### PR TITLE
fix bug in calculating adjusted bpm of the score

### DIFF
--- a/matchmaker/matchmaker.py
+++ b/matchmaker/matchmaker.py
@@ -241,7 +241,7 @@ class Matchmaker(object):
             if self.performance_file is not None:
                 # tempo is slightly adjusted to reflect the tempo of the performance audio
                 self.tempo = adjust_tempo_for_performance_audio(
-                    self.score_part, self.performance_file
+                    self.score_part, self.performance_file, self.tempo
                 )
 
             # generate score audio

--- a/matchmaker/utils/misc.py
+++ b/matchmaker/utils/misc.py
@@ -191,7 +191,9 @@ def interleave_with_constant(
     return interleaved_array
 
 
-def adjust_tempo_for_performance_audio(score: ScoreLike, performance_audio: Path):
+def adjust_tempo_for_performance_audio(
+    score: ScoreLike, performance_audio: Path, default_tempo: int = 120
+):
     """
     Adjust the tempo of the score part to match the performance audio.
     We round up the tempo to the nearest 20 bpm to avoid too much optimization.
@@ -202,26 +204,16 @@ def adjust_tempo_for_performance_audio(score: ScoreLike, performance_audio: Path
         The score to adjust the tempo of.
     performance_audio : Path
         The performance audio file to adjust the tempo to.
+    default_tempo : int
+        The default tempo of the score.
     """
-    default_tempo = 120
-    # score_midi = partitura.save_score_midi(score, out=None)
-    # tmp_score_path = "score.mid"
-    # partitura.save_score_midi(score, out=tmp_score_path)
-    # source_length = mido.MidiFile(tmp_score_path).length
-
-    sna = score.note_array()
-    pna = performance_notearray_from_score_notearray(
-        snote_array=sna,
-        bpm=default_tempo,
-    )
-
-    source_length = np.max(pna["onset_sec"] + pna["duration_sec"])
+    score_midi = partitura.save_score_midi(score, out=None)
+    source_length = score_midi.length
     target_length = librosa.get_duration(path=str(performance_audio))
     ratio = target_length / source_length
     rounded_tempo = int(
         (default_tempo / ratio + 19) // 20 * 20
     )  # round up to nearest 20
-    # rounded_tempo = round(default_tempo / ratio / 20) * 20
     print(
         f"default tempo: {default_tempo} (score length: {source_length}) -> adjusted_tempo: {rounded_tempo} (perf length: {target_length})"
     )


### PR DESCRIPTION
There were a bug in calculating the source length of the score (changed in https://github.com/pymatchmaker/matchmaker/commit/330279ad177db2288d38502561afedd4b75df4c0), especially for non 4/4 time signature pieces (e.g. 2/2, 6/8).

It can be simply solved by directly getting the `length` of the score midi generated by partitura.