### PR TITLE
Fix: incorrect path in README installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ conda create -n matchmaker python=3.12
 conda activate matchmaker
 
 # Go to matchmaker directory
-cd ../matchmaker
+cd matchmaker
 
 # Install matchmaker in editable mode
 pip install -e ."[dev]"


### PR DESCRIPTION
I couldn't think of a scenario where the `cd ../matchmaker` command fits into the installation instructions. Hence the proposed change from `cd ../matchmaker` to `cd matchmaker`.