### PR TITLE
apply 1ms polling_period to symbolic arzt/dixon/outerhmm, set mininum note_on time for midi buffer

### DIFF
--- a/matchmaker/features/midi.py
+++ b/matchmaker/features/midi.py
@@ -92,22 +92,25 @@ class PitchProcessor(Processor):
 
         # TODO: Replace the for loop with list comprehension
         pitch_obs_list = []
+        note_times = []
 
-        for msg, _ in data:
+        for msg, m_time in data:
             if (
                 getattr(msg, "type", "other") == "note_on"
                 and getattr(msg, "velocity", 0) > 0
             ):
                 pitch_obs[msg.note] = 1
                 pitch_obs_list.append(msg.note - self.piano_shift)
+                note_times.append(m_time)
 
         if pitch_obs.sum() > 0:
             if self.piano_range:
                 pitch_obs = pitch_obs[21:109]
 
+            obs_time = min(note_times)
             if self.return_pitch_list:
-                return np.array(pitch_obs_list, dtype=np.float32), f_time
-            return pitch_obs, f_time
+                return np.array(pitch_obs_list, dtype=np.float32), obs_time
+            return pitch_obs, obs_time
         else:
             return None
 
@@ -151,7 +154,7 @@ class PianoRollProcessor(Processor):
 
     Notes
     -----
-    Contrast with ``OnsetOnlyPianoRollProcessor``, which only encodes
+    Contrast with ``ChordOnsetProcessor``, which only encodes
     onsets (note_ons) without sustain. Use this processor when the
     downstream model needs a "what is currently sounding" snapshot
     (e.g. matching against frame-sampled audio features).
@@ -204,50 +207,14 @@ class PianoRollProcessor(Processor):
         self.active_notes = dict()
 
 
-class OnsetOnlyPianoRollProcessor(Processor):
-    """Binary pianoroll per chord onset (no sustain), with streaming chord grouping.
+class ChordOnsetProcessor(Processor):
+    """Emit one binary pitch vector per chord/onset.
 
-    Tracks only ``note_on`` events (ignores ``note_off``). Accumulates
-    note-ons into a pending chord and emits the chord vector when the
-    gap between consecutive ``note_on`` arrival times exceeds
-    ``chord_threshold``. Notes within the gap are merged into one
-    observation (chord stacking).
-
-    Stateful: pending notes are held across calls until the next note
-    arrives more than ``chord_threshold`` later. Use
-    ``flush_remaining()`` at end-of-stream to emit any last pending
-    chord that has no following onset.
-
-    Parameters
-    ----------
-    piano_range : bool, default True
-        If True, restrict to 88-key piano range (MIDI 21-108).
-        Otherwise 128 pitches.
-    chord_threshold : float, default ``CHORD_THRESHOLD`` (35 ms)
-        Maximum gap (seconds) between consecutive ``note_on`` times to
-        consider them part of the same chord. Larger gap triggers flush.
-    dtype : type, default np.float32
-        Numpy dtype of the output vector.
-
-    Returns
-    -------
-    None while accumulating (pending chord not yet flushed) or for
-    frames with no relevant ``note_on``. Otherwise a tuple
-    ``(pianoroll, t)`` where:
-        - ``pianoroll``: ``np.ndarray`` of shape ``(88,)`` when
-          ``piano_range=True`` else ``(128,)``. Binary (0/1) with 1 at
-          indices of every pitch in the flushed chord.
-          Example: chord (C4, E4, G4) flushed with default piano range
-          → vector with 1 at indices 39, 43, 46 (=pitch-21).
-        - ``t``: time (seconds) of the FIRST ``note_on`` in the flushed
-          chord — the chord onset time, not the frame emit time. Useful
-          for downstream IOI computation that wants the actual chord
-          onset.
-
-    Notes
-    -----
-    Designed for event-level MIDI OLTW (arzt/dixon), where the score
-    side is a binary onset pianoroll per unique score onset.
+    Note-ons within ``chord_threshold`` are merged into one chord. This
+    processor is intended to be paired with short windowed MIDI polling
+    (e.g. 1 ms): empty frames then act as a heartbeat and emit a pending
+    chord once the threshold has elapsed, without waiting for the next
+    note. The emitted timestamp is the first note-on time of the chord.
     """
 
     def __init__(
@@ -277,7 +244,7 @@ class OnsetOnlyPianoRollProcessor(Processor):
         return (vec, t)
 
     def __call__(self, frame: InputMIDIFrame) -> Optional[Tuple[np.ndarray, float]]:
-        data, _ = frame
+        data, f_time = frame
 
         result = None
         for msg, m_time in data:
@@ -293,6 +260,17 @@ class OnsetOnlyPianoRollProcessor(Processor):
                 self._pending_notes.append(msg.note)
                 if self._pending_time is None:
                     self._pending_time = m_time
+
+        # In windowed streams, empty frames still call the processor. Use
+        # their frame time as a heartbeat so a pending chord can be emitted
+        # without waiting for the next note_on.
+        if (
+            result is None
+            and self._pending_time is not None
+            and (f_time - self._pending_time) > self.chord_threshold
+            and self._pending_notes
+        ):
+            result = self._flush()
 
         return result
 

--- a/matchmaker/io/midi.py
+++ b/matchmaker/io/midi.py
@@ -26,6 +26,7 @@ from matchmaker.utils.symbolic import (
 
 # Default polling period (in seconds)
 POLLING_PERIOD = 0.01
+ONLINE_WINDOW_INTERVAL = 0.00001
 
 
 class MidiStream(Stream):
@@ -191,10 +192,8 @@ class MidiStream(Stream):
         frame = Buffer(self.polling_period)
         frame.start = self.current_time
 
-        # TODO: check the effect of smaller st
-        st = self.polling_period * 0.001
         while self.listen:
-            time.sleep(st)
+            time.sleep(ONLINE_WINDOW_INTERVAL)
             if self.listen:
                 # added if to check once again after sleep
                 c_time = self.current_time

--- a/matchmaker/matchmaker.py
+++ b/matchmaker/matchmaker.py
@@ -29,7 +29,7 @@ from matchmaker.features.audio import (
     RawSpectrumProcessor,
 )
 from matchmaker.features.midi import (
-    OnsetOnlyPianoRollProcessor,
+    ChordOnsetProcessor,
     PianoRollProcessor,
     PitchClassPianoRollProcessor,
     PitchProcessor,
@@ -99,15 +99,17 @@ DEFAULT_KWARGS = {
     },
     "midi": {
         "arzt": {
-            "processor": "onset_only_pianoroll",
+            "processor": "chord_onset",
             "piano_range": True,
+            "polling_period": 0.001,
             "window_size": 2,
             "start_window_size": 2,
             "step_size": 5,
         },
         "dixon": {
-            "processor": "onset_only_pianoroll",
+            "processor": "chord_onset",
             "piano_range": True,
+            "polling_period": 0.001,
             "window_size": 0.3,
         },
         "hmm": {
@@ -121,7 +123,11 @@ DEFAULT_KWARGS = {
             "num_particles": 1000,
         },
         "pthmm": {"processor": "pitch", "piano_range": True},
-        "outerhmm": {"processor": "pitch", "piano_range": True},
+        "outerhmm": {
+            "processor": "chord_onset",
+            "piano_range": True,
+            "polling_period": 0.001,
+        },
         "SLT_OLTW": {"processor": "pitch", "piano_range": True},
         "SL_OLTW": {"processor": "pitch", "piano_range": True},
         "OTM": {"processor": "pitch", "piano_range": True},
@@ -178,7 +184,7 @@ class Matchmaker(object):
         **midi keys**
 
         - ``processor`` (str): Feature type. Default: ``"pitch"``.
-          Choices: ``"pitch"``, ``"pianoroll"``, ``"onset_only_pianoroll"``,
+          Choices: ``"pitch"``, ``"pianoroll"``, ``"chord_onset"``,
           ``"pitchclass"``.
         - ``piano_range`` (bool): Restrict pitch to 88-key piano range
           (MIDI 21-108). Default: True.
@@ -351,7 +357,7 @@ class Matchmaker(object):
             "pianoroll": lambda: PianoRollProcessor(
                 piano_range=self.config["piano_range"],
             ),
-            "onset_only_pianoroll": lambda: OnsetOnlyPianoRollProcessor(
+            "chord_onset": lambda: ChordOnsetProcessor(
                 piano_range=self.config.get("piano_range", True),
             ),
         }

--- a/matchmaker/prob/outer_product_hmm.py
+++ b/matchmaker/prob/outer_product_hmm.py
@@ -304,19 +304,6 @@ class OuterProductHMM(OnlineAlignment):
     def __call__(
         self, observation: np.ndarray, perf_time: float, *args, **kwargs
     ) -> Optional[float]:
-        # Chord-continuation case: merge pitches into the pending chord and
-        # signal `None` to run() so the patience counter stays put. We don't
-        # call super() because no state advance / path append should happen.
-        pitch_obs = observation
-        ioi = (
-            perf_time - self._prev_perf_time
-            if self._prev_perf_time is not None
-            else 0.0
-        )
-        self._prev_perf_time = perf_time
-        if ioi < IOI_THRESHOLD:
-            self._current_chord = np.maximum(self._current_chord, pitch_obs)
-            return None
         return super().__call__(observation, perf_time)
 
     def step(self, features) -> None:

--- a/matchmaker/utils/typing.py
+++ b/matchmaker/utils/typing.py
@@ -15,7 +15,7 @@ Aliases
     - ``messages`` : ``List[Tuple[mido.Message, float]]``. Each entry is
       a MIDI message paired with the per-message arrival time
       (``m_time``). Stateful processors that group across messages
-      (e.g. :class:`~matchmaker.features.midi.OnsetOnlyPianoRollProcessor`)
+      (e.g. :class:`~matchmaker.features.midi.ChordOnsetProcessor`)
       use these ``m_time`` values to decide chord boundaries.
     - ``frame_time`` : ``float``. The stream's nominal time for the
       frame. Stateless processors (e.g.


### PR DESCRIPTION
- Added `ChordOnsetProcessor` which requires wider window for grouping notes as a chord. symbolic arzt/dixon/outerhmm uses this.

<img width="1372" height="797" alt="image" src="https://github.com/user-attachments/assets/dd43f61f-5b0b-441b-b392-0fd80266a953" />

⓵ By default, most symbolic trackers in matchmaker uses `PitchProcessor`, coupled with 10ms of `polling_period`. it groups the note events within 10ms window.
⓶ For symbolic arzt/dixon/outerhmm, these algorithms require wider window for grouping multiple notes as 'chords', so I implemented like ② (without polling) in current develop version. But this triggers one-note lagging issue, because the chords are only confirmed when next note arrives. (should not be used, especially in real streaming demo setting)
⓷ This is a compromise between 1&2, `ChordOnsetProcessor`, with much shorter polling interval(1ms) to trigger the chord flush. For shorter polling period, I think it won't be a problem because the thread for MidiStream + Processor is separated from the Alignment thread (queue is the communication b/w two threads), and mostly stream/processor takes less than 10us, tested on my Ubuntu (1ms=1000us). The flush can be triggered either by a later `note_on` crossing the threshold or by a polling heartbeat. In both cases, the confirmed chord is consumed, and the next group starts fresh from the next ungrouped `note_on`.