### PR TITLE
Feature/bytesmidistream

### DIFF
--- a/matchmaker/__init__.py
+++ b/matchmaker/__init__.py
@@ -7,7 +7,7 @@ Matchmaker is a library for real-time music alignment
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
-from . import dp, external, features, io, prob, utils
+from . import dp, features, io, prob, utils
 from .matchmaker import *
 
 __all__ = ["dp", "features", "io", "prob", "utils"]

--- a/matchmaker/io/midi.py
+++ b/matchmaker/io/midi.py
@@ -342,8 +342,10 @@ class BytesMidiStream(MidiStream):
     into ``mido.Message`` instances which then flow through the regular
     ``MidiStream`` processor pipeline.
 
-    Single-message mode only (no windowing): each parsed message is
-    processed individually, mirroring how Web MIDI events arrive.
+    By default, each parsed message is processed individually, mirroring how
+    Web MIDI events arrive. If ``polling_period`` is provided, incoming
+    messages are accumulated into timed MIDI windows and empty windows act as
+    heartbeats for processors that need frame timing.
 
     Parameters
     ----------
@@ -354,6 +356,8 @@ class BytesMidiStream(MidiStream):
         ``None`` (disconnect sentinel).
     queue : RECVQueue, optional
         Output queue for processed features. Created if omitted.
+    polling_period : float, optional
+        Window duration in seconds. ``None`` keeps event-based processing.
     return_midi_messages : bool, default False
         If True, emit ``((msg, c_time), features)`` instead of features.
 
@@ -384,6 +388,7 @@ class BytesMidiStream(MidiStream):
         processor: Optional[Processor] = None,
         data_queue: Optional[_queue.Queue] = None,
         queue: Optional[RECVQueue] = None,
+        polling_period: Optional[float] = None,
         return_midi_messages: bool = False,
     ) -> None:
         if processor is None:
@@ -410,11 +415,15 @@ class BytesMidiStream(MidiStream):
         self.return_midi_messages = return_midi_messages
         self.mediator = None
         self.midi_messages = []
-        self.polling_period = None
-        self.is_windowed = False
+        self.polling_period = polling_period
+        self.is_windowed = polling_period is not None
 
     def run(self) -> None:
         """Pull MIDI byte chunks from ``data_queue``, parse, and process."""
+        if self.is_windowed:
+            self._run_windowed()
+            return
+
         self.start_listening()
         while self.listen:
             try:
@@ -431,6 +440,43 @@ class BytesMidiStream(MidiStream):
                 c_time = self.current_time
                 self.add_midi_message(msg=msg, time=c_time)
                 self._process_frame_message(data=msg, c_time=c_time)
+
+    def _run_windowed(self) -> None:
+        self.start_listening()
+        frame = Buffer(self.polling_period)
+        frame.start = self.current_time
+
+        while self.listen:
+            try:
+                data = self.data_queue.get(timeout=ONLINE_WINDOW_INTERVAL)
+            except _queue.Empty:
+                data = b""
+
+            c_time = self.current_time
+            if data is None:
+                self.stop_listening()
+                break
+            if data:
+                self._parser.feed(data)
+                for msg in self._parser:
+                    self.add_midi_message(msg=msg, time=c_time)
+                    if msg.type in ["note_on", "note_off"]:
+                        frame.append(msg, c_time)
+                        if not self.first_msg:
+                            self.first_msg = True
+
+            if c_time >= frame.end and self.first_msg:
+                self._process_frame_window(data=frame)
+                frame.reset(c_time)
+
+        self._finish_stream()
+
+    def _finish_stream(self) -> None:
+        if hasattr(self.processor, "flush_remaining"):
+            last = self.processor.flush_remaining()
+            if last is not None:
+                self.queue.put(last)
+        self.queue.put(STREAM_END)
 
     def stop(self) -> None:
         """Stop the stream and unblock any pending ``data_queue.get``."""

--- a/matchmaker/matchmaker.py
+++ b/matchmaker/matchmaker.py
@@ -16,7 +16,6 @@ from matchmaker.dp import (
     OnlineTimeWarpingDixonEvent,
     OnlineTimeWarpingDixonFrame,
 )
-from matchmaker.external import OnlineParangonarAlignment
 from matchmaker.features.audio import (
     FRAME_RATE,
     SAMPLE_RATE,
@@ -516,6 +515,8 @@ class Matchmaker(object):
                 num_particles=self.config.get("num_particles", 1000),
             )
         elif method in PARANGONAR_METHODS:
+            from matchmaker.external import OnlineParangonarAlignment
+
             sna = self.score_part.note_array(include_grace_notes=True)
             return OnlineParangonarAlignment(
                 reference_features=sna,

--- a/matchmaker/prob/outer_product_hmm_audio.py
+++ b/matchmaker/prob/outer_product_hmm_audio.py
@@ -308,6 +308,9 @@ class AudioOuterProductHMM(OnlineAlignment):
         observation = np.asarray(input, dtype=float)
         self.current_perf_time = float(perf_time)
 
+        if observation.size == 0:
+            return self.current_position
+
         if observation.ndim == 2:
             observation = observation[-1]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "progressbar2>=4.2.0",
     "python-hiddenmarkov>=0.1.3",
     "matplotlib>=3.9.4",
-    "parangonar",
+    "parangonar>=3.3.2",
     "mido>=1.3.2",
     "pyfluidsynth>=1.3.3",
 ]


### PR DESCRIPTION
Updates to `BytesMidiStream` that takes polling_period as an argument. This is similar to `MidiStream`. The `BytesMidiStream` is for application that doesn't involve 'local devices' such as browser-based MIDI input, which is directly used by matchmaker-demo.